### PR TITLE
Blog page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ www/wp-content/plugins/events-calendar-pro
 www/wp-content/plugins/gravityforms*
 www/wp-content/plugins/advanced-custom-fields-pro
 www/wp-content/plugins/acf-repeater
+
+# IDE
+.idea

--- a/www/wp-content/themes/wp-theme/assets/sass/modules/_blog-pagination.sass
+++ b/www/wp-content/themes/wp-theme/assets/sass/modules/_blog-pagination.sass
@@ -1,0 +1,5 @@
+.blog-pagination
+  .previous
+    float: left
+  .next
+    float: right

--- a/www/wp-content/themes/wp-theme/assets/sass/style.sass
+++ b/www/wp-content/themes/wp-theme/assets/sass/style.sass
@@ -38,6 +38,7 @@
 @import modules/_defaults
 @import modules/_input
 @import modules/js-breakpoints
+@import modules/blog-pagination
 
 // WordPress
 @import modules/_wordpress-default

--- a/www/wp-content/themes/wp-theme/ie.css
+++ b/www/wp-content/themes/wp-theme/ie.css
@@ -1010,6 +1010,15 @@ body:after {
   display: none;
 }
 
+/* line 2, assets/sass/modules/_blog-pagination.sass */
+.blog-pagination .previous {
+  float: left;
+}
+/* line 4, assets/sass/modules/_blog-pagination.sass */
+.blog-pagination .next {
+  float: right;
+}
+
 /** WORDPRESS DEFAULT
  *=================================== */
 /* line 6, assets/sass/modules/_wordpress-default.sass */

--- a/www/wp-content/themes/wp-theme/partials/blog-list.php
+++ b/www/wp-content/themes/wp-theme/partials/blog-list.php
@@ -1,0 +1,55 @@
+<?php
+
+// If this is the blog template get posts_per_page from WP settings otherwise default to whatevs
+$isBlogTemplate = basename(get_page_template()) == 'template-blog.php';
+$postsPerPage = $isBlogTemplate ? get_option('posts_per_page') : 3;
+
+$paged = ( get_query_var('paged') ) ? get_query_var('paged') : 1;
+$news = new WP_Query(array(
+    "post_type" => "post",
+    "posts_per_page" => $postsPerPage,
+    'paged' => $paged
+));
+
+while( $news->have_posts() ) {
+    $news->the_post();
+
+    // determine photo to use. use hero unless it's not defined.
+    $hero_image = get_field( 'hero_image' );
+    if( !empty($hero_image) ){
+        $featured_img = '<img src="' . $hero_image['sizes']['square-medium'] . '" alt="" />';
+    }else{
+        $featured_img = get_avatar( get_the_author_meta( 'ID' ), 300, null, get_the_author() );
+    }
+
+    ?>
+    <article class="post">
+        <header>
+            <h3><a href="<?php the_permalink() ?>"><?php the_title() ?></a></h3>
+            <span class="date">posted <?php the_time('F j, Y');?></span>
+            <a href="<?php the_permalink() ?>"><?php echo $featured_img ?></a>
+        </header>
+
+        <div class="content">
+            <?php the_excerpt() ?>
+            <a href="<?php the_permalink() ?>" class="more">Read More</a>
+        </div>
+
+    </article>
+<?php
+}
+
+wp_reset_postdata();
+
+?>
+
+<?php if ($news->max_num_pages > 1 && $isBlogTemplate) {  ?>
+    <nav class="blog-pagination cf">
+        <div class="previous">
+            <?php echo get_next_posts_link( 'Older Entries', $news->max_num_pages ); ?>
+        </div>
+        <div class="next">
+            <?php echo get_previous_posts_link( 'Newer Entries' ); ?>
+        </div>
+    </nav>
+<?php } ?>

--- a/www/wp-content/themes/wp-theme/style.css
+++ b/www/wp-content/themes/wp-theme/style.css
@@ -1040,6 +1040,15 @@ textarea {
     display: none;
   }
 }
+/* line 2, assets/sass/modules/_blog-pagination.sass */
+.blog-pagination .previous {
+  float: left;
+}
+/* line 4, assets/sass/modules/_blog-pagination.sass */
+.blog-pagination .next {
+  float: right;
+}
+
 /** WORDPRESS DEFAULT
  *=================================== */
 /* line 6, assets/sass/modules/_wordpress-default.sass */

--- a/www/wp-content/themes/wp-theme/template-blog.php
+++ b/www/wp-content/themes/wp-theme/template-blog.php
@@ -1,0 +1,18 @@
+<?php
+/*
+Template Name: Blog
+*/
+get_header();
+the_post();
+?>
+
+<?php include('partials/hero.php'); ?>
+
+    <section class="post-list main">
+        <div class="middlifier">
+            <?php include('partials/blog-list.php'); ?>
+        </div>
+    </section>
+
+
+<?php get_footer() ?>

--- a/www/wp-content/themes/wp-theme/template-home.php
+++ b/www/wp-content/themes/wp-theme/template-home.php
@@ -15,44 +15,7 @@ the_post();
 			<h2>Updates</h2>
 		</header>
 
-		<?php
-
-		$news = new WP_Query(array(
-			"post_type" => "post",
-			"posts_per_page" => 3
-		));
-
-		while( $news->have_posts() ) {
-			$news->the_post();
-
-			// determine photo to use. use hero unless it's not defined.
-			$hero_image = get_field( 'hero_image' );
-			if( !empty($hero_image) ){
-				$featured_img = '<img src="' . $hero_image['sizes']['square-medium'] . '" alt="" />';
-			}else{
-				$featured_img = get_avatar( get_the_author_meta( 'ID' ), 300, null, get_the_author() );
-			}
-
-			?>
-			<article class="post">
-				<header>
-					<h3><a href="<?php the_permalink() ?>"><?php the_title() ?></a></h3>
-					<span class="date">posted <?php the_time('F j, Y');?></span>
-					<a href="<?php the_permalink() ?>"><?php echo $featured_img ?></a>
-				</header>
-
-				<div class="content">
-					<?php the_excerpt() ?>
-					<a href="<?php the_permalink() ?>" class="more">Read More</a>
-				</div>
-
-			</article>
-			<?php
-		}
-
-		wp_reset_postdata();
-
-		?>
+		<?php include('partials/blog-list.php'); ?>
 	</div>
 </section>
 


### PR DESCRIPTION
Branch for https://trello.com/c/lFThuFW4/36-blog-listing

I'll basically repeat my commit log messages in more depth here.

tldr; - read the logs

I opted to use a page template for the blog page but we can certainly use the index or archive approach if desired.  I kind of like keeping it as a page just for the ease of flexibility, but whatevs.

I ripped out the functionality from the home page news listing and popped it into a partial.  Added a little bit of logic to juggle the differences from home page to blog listing, mainly, pagination settings.

The home page will stick to the 3 posts as it already was but the blog page will default to whatever the read settings are in WP.

The styling has been kept very minimal - really, the same as the home, sans the "updates" headline.  There is a simple navigation below the post entries that read "Older Entries" and "Newer Entries".  Please change that to whatever sounds best.  Minimal styling just to float the two links.

To implement the changes, simply add a new page and use the Blog template.